### PR TITLE
I18nliner compatibility, easier usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Write HTML markup inside a special `<Text />` React component and it will be use
 This JSX:
 
 ```javascript
-<Text phrase="greeting">
+<Text key="greeting">
     <p>Hello World!</p>
 </Text>
 ```
@@ -26,7 +26,7 @@ Compiles into something like this:
 } />
 ```
 
-The output will be more compact than the above making it ready to be injected *anywhere*. And of course, we're assuming that an `I18n` variable is in-scope.
+The output will be more compact than the above making it ready to be injected *anywhere*. And of course, we're assuming that an `I18n` variable is in-scope. canvas_react_i18n assumes you are using [i18n-js](https://github.com/fnando/i18n-js) in conjunction with [i18nliner](https://github.com/jenseng/i18nliner-js)
 
 See the `test/fixtures/` folder for more examples. It contains pairs of files; raw JSX inputs and their compiled outputs.
 

--- a/lib/extract_text_blocks.js
+++ b/lib/extract_text_blocks.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var CallHelpers = require('i18nliner/dist/lib/call_helpers')['default'];
 
 var underscoreStr = function(str) {
   return str.replace(/([A-Z])/g, function($1){
@@ -7,7 +8,7 @@ var underscoreStr = function(str) {
 };
 
 // Locates a starting <Text ... > and closing </Text> tags:
-var TEXT_TAG_START = /<Text[^>]+>/m;
+var TEXT_TAG_START = /<Text[^>]*>/m;
 var TEXT_TAG_END = '</Text>';
 
 // Capture all attribute tags inside the opening <Text> tag. E.g:
@@ -17,10 +18,10 @@ var TEXT_TAG_END = '</Text>';
 // Yields a capture:
 //
 //     key="foo" name="Ahmad"
-var TEXT_PROPS_EXTRACTOR = /<Text([^>]+)>/;
+var TEXT_PROPS_EXTRACTOR = /<Text([^>]*)>/;
 
 // Locates the leading <Text> and trailing </Text>:
-var TEXT_TAG_STRIPPER = /^<Text[^>]+>|<\/Text>$/g;
+var TEXT_TAG_STRIPPER = /^<Text[^>]*>|<\/Text>$/g;
 
 var I18N_DIRECTIVE = _.template([
   '<%= func %>("<%= key %>", "<%= defaultValue %>", <%= options %>)'
@@ -139,9 +140,14 @@ var extract = function(textBlock, dontCompile) {
   };
 
   var getParams = function(tag) {
-    return tag
+    tag = tag
       .replace(/\s+/g, ' ')
-      .trim()
+      .trim();
+    if (!tag) {
+      return [];
+    }
+
+    return tag
       .split(' ')
       .map(function(prop) {
         return prop.trim().replace(/"/g, '').split('=');
@@ -172,12 +178,12 @@ var extract = function(textBlock, dontCompile) {
     return set;
   }, {});
 
-  i18n.key = i18nKey;
   i18n.options = i18nParams;
   i18n.defaultValue = textBlock
     .replace(TEXT_TAG_STRIPPER, '') // remove <Text ...> and </Text>
     .replace(/[\n\s]+/g, ' ')       // no newlines, use spaces instead
     .trim();
+  i18n.key = i18nKey || CallHelpers.inferKey(i18n.defaultValue);
 
   // Generate the actual I18n.t() directive
   if (!dontCompile) {

--- a/lib/extract_text_blocks.js
+++ b/lib/extract_text_blocks.js
@@ -12,24 +12,24 @@ var TEXT_TAG_END = '</Text>';
 
 // Capture all attribute tags inside the opening <Text> tag. E.g:
 //
-//     <Text phrase="foo" name="Ahmad">...</Text>
+//     <Text key="foo" name="Ahmad">...</Text>
 //
 // Yields a capture:
 //
-//     phrase="foo" name="Ahmad"
+//     key="foo" name="Ahmad"
 var TEXT_PROPS_EXTRACTOR = /<Text([^>]+)>/;
 
 // Locates the leading <Text> and trailing </Text>:
 var TEXT_TAG_STRIPPER = /^<Text[^>]+>|<\/Text>$/g;
 
 var I18N_DIRECTIVE = _.template([
-  '<%= func %>("<%= phrase %>", "<%= defaultValue %>", <%= options %>)'
+  '<%= func %>("<%= key %>", "<%= defaultValue %>", <%= options %>)'
 ].join(''));
 
 var I18N_DIRECTIVE_WITH_WRAPPER = _.template([
   '(function(){',
     'var wrapper=<%=wrapper%>;',
-    'return <%= func %>("<%= phrase %>", "<%= defaultValue %>", <%= options %>);',
+    'return <%= func %>("<%= key %>", "<%= defaultValue %>", <%= options %>);',
   '}())'
 ].join(''));
 
@@ -37,7 +37,18 @@ var config = {
   func: 'I18n.t'
 };
 
-var PHRASE_PROP = 'phrase';
+var isKey = function(property) {
+  var key = property.key;
+  if (key === "key") return true;
+  if (key !== "phrase") return false;
+  console.warn("`phrase` is deprecated; use `key` instead, or just rely on inferred keys");
+  return true;
+};
+var not = function(fn) {
+  return function() {
+    return !fn.apply(this, arguments);
+  };
+}
 
 var normalizeStr = function(str) {
   return str.replace(/"/g, '\\"');//.replace(/\n+/g, ' ');
@@ -70,7 +81,7 @@ var dumpOptions = function(options) {
   return JSON.stringify(options).replace(/\"\{|\}\"/g, '');
 };
 
-var compile = function(phrase, defaultValue, options, wrapper) {
+var compile = function(key, defaultValue, options, wrapper) {
   var directive;
 
   if (wrapper) {
@@ -83,7 +94,7 @@ var compile = function(phrase, defaultValue, options, wrapper) {
 
   return directive({
     func: config.func,
-    phrase: phrase,
+    key: key,
     defaultValue: normalizeStr(defaultValue),
     options: dumpOptions(options),
     wrapper: wrapper ? dumpOptions(wrapper) : 'undefined'
@@ -101,9 +112,9 @@ var compile = function(phrase, defaultValue, options, wrapper) {
  *         A string containing a *single* <Text>...</Text> React component.
  *
  * @return {Object} i18n
- *
- * @return {String} i18n.phrase
- *         The phrase you're translating; the "name" in `I18n.t("name")`.
+ *q
+ * @return {String} i18n.key
+ *         The key you're translating; the "name" in `I18n.t("name")`.
  *
  * @return {String} i18n.defaultValue
  *         The text or HTML contents of the <Text> component. Beware that this
@@ -116,16 +127,14 @@ var compile = function(phrase, defaultValue, options, wrapper) {
  *         interpolating.
  *
  * @return {String} i18n.stringValue
- *         The full call to I18n.t() with the proper phrase, its default value,
+ *         The full call to I18n.t() with the proper key, its default value,
  *         and any options. This can be `eval()`d inside a Canvas environment
  *         and it would yield the proper value.
  */
 var extract = function(textBlock, dontCompile) {
-  var getPhrase = function(params) {
-    return params.filter(function(prop) {
-      return prop.key === PHRASE_PROP;
-    }).map(function(phraseProp) {
-      return phraseProp.value;
+  var getKey = function(params) {
+    return params.filter(isKey).map(function(keyProp) {
+      return keyProp.value;
     })[0];
   };
 
@@ -146,26 +155,24 @@ var extract = function(textBlock, dontCompile) {
   };
 
   var i18n = {
-    phrase: null,
+    key: null,
     defaultValue: null,
     stringValue: '',
     options: {},
     compile: function(wrapper) {
-      return compile(i18n.phrase, i18n.defaultValue, i18n.options, wrapper);
+      return compile(i18n.key, i18n.defaultValue, i18n.options, wrapper);
     }
   };
 
   var textTagStart = textBlock.match(TEXT_PROPS_EXTRACTOR)[1];
   var tagParams = getParams(textTagStart);
-  var i18nPhrase = getPhrase(tagParams);
-  var i18nParams = tagParams.filter(function(prop) {
-    return prop.key !== PHRASE_PROP;
-  }).reduce(function(set, entry) {
+  var i18nKey = getKey(tagParams);
+  var i18nParams = tagParams.filter(not(isKey)).reduce(function(set, entry) {
     set[underscoreStr(entry.key)] = entry.value;
     return set;
   }, {});
 
-  i18n.phrase = i18nPhrase;
+  i18n.key = i18nKey;
   i18n.options = i18nParams;
   i18n.defaultValue = textBlock
     .replace(TEXT_TAG_STRIPPER, '') // remove <Text ...> and </Text>

--- a/lib/extract_text_blocks.js
+++ b/lib/extract_text_blocks.js
@@ -11,6 +11,11 @@ var underscoreStr = function(str) {
 var TEXT_TAG_START = /<Text[^>]*>/m;
 var TEXT_TAG_END = '</Text>';
 
+// DANGER: does not support curly-braces within the expression.
+// Prefix check is important to ensure we don't mangle explicit
+// i18n-style interpolation
+var JS_EXPRESSION = /(^|[^%])(\{.*?\})/g;
+
 // Capture all attribute tags inside the opening <Text> tag. E.g:
 //
 //     <Text key="foo" name="Ahmad">...</Text>
@@ -53,6 +58,55 @@ var not = function(fn) {
 
 var normalizeStr = function(str) {
   return str.replace(/"/g, '\\"');//.replace(/\n+/g, ' ');
+};
+
+// DRY alert, this is borrowed/adapted from i18nliner-handlebars ...
+// might make sense to move some of it up into i18nliner-js
+var normalizeInterpolationKey = function(string) {
+  return string.replace(/[^a-z0-9]/gi, ' ')
+    .replace(/([A-Z\d]+|[a-z])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .trim()
+    .replace(/ +/g, '_')
+    .substring(0, 32);
+};
+
+var inferInterpolationKey = function(string, options) {
+  var key;
+  var baseKey;
+  var i;
+  // remove some superfluous stuff that doesn't add value to the key
+  key = string.replace(/this\.(props|state)\./g, '');
+  key = normalizeInterpolationKey(key);
+  baseKey = key;
+  // make sure the key is unique in case a slightly different string
+  // results in the same value
+  while (options[key] && options[key] !== baseKey) {
+    key = baseKey + '_' + i;
+    i++;
+  }
+  return key;
+};
+
+/**
+ * Change any javascript expressions into I18n placeholders, whether they
+ * apppear in the main string or a future inferred wrapper (i18nliner
+ * handles both types correctly)
+ */
+var extractPlaceholders = function(string, options) {
+  return string.replace(JS_EXPRESSION, function(match, prefix, expression) {
+    var key = inferInterpolationKey(expression, options);
+    options[key] = expression; // expression includes the {}, for dumpOptions
+
+    // if the prefix is a "=", assume we are using this as an attribute,
+    // and quote it accordingly (since it won't be handled by react)...
+    // i18nliner will handle html-safety, but we need to quote so we don't
+    // end the attribute prematurely due to whitespace
+    // TODO: make this more robust
+    return (prefix === '=') ?
+      prefix + '"%{' + key + '}"' :
+      prefix + '%{' + key + '}';
+  });
 };
 
 /**
@@ -104,7 +158,7 @@ var compile = function(key, defaultValue, options, wrapper) {
 
 /**
  * Given a <Text>...</Text> component string, this method will extract several
- * i18n items and construct an I18n.t() directive that would work in Canvas.
+ * i18n items and construct an I18n.t() directive that would work with i18nliner.
  *
  * Note: you should not use this directly, use #extractTextBlocks() instead as
  * it takes care of extracting all blocks in a given source string.
@@ -129,7 +183,7 @@ var compile = function(key, defaultValue, options, wrapper) {
  *
  * @return {String} i18n.stringValue
  *         The full call to I18n.t() with the proper key, its default value,
- *         and any options. This can be `eval()`d inside a Canvas environment
+ *         and any options. This can be `eval()`d in an i18nliner-enabled app
  *         and it would yield the proper value.
  */
 var extract = function(textBlock, dontCompile) {
@@ -183,6 +237,7 @@ var extract = function(textBlock, dontCompile) {
     .replace(TEXT_TAG_STRIPPER, '') // remove <Text ...> and </Text>
     .replace(/[\n\s]+/g, ' ')       // no newlines, use spaces instead
     .trim();
+  i18n.defaultValue = extractPlaceholders(i18n.defaultValue, i18n.options);
   i18n.key = i18nKey || CallHelpers.inferKey(i18n.defaultValue);
 
   // Generate the actual I18n.t() directive

--- a/package.json
+++ b/package.json
@@ -34,11 +34,16 @@
   },
 
   "devDependencies": {
+    "i18nliner": "^0.0.16",
     "jasmine-node": "^1.14.3",
     "jshint": "x"
   },
 
   "dependencies": {
     "lodash": "x"
+  },
+
+  "peerDependencies": {
+    "i18nliner": "^0.0.16"
   }
 }

--- a/test/extract_text_blocks_spec.js
+++ b/test/extract_text_blocks_spec.js
@@ -3,13 +3,20 @@ var path = require('path');
 var loadFixture = require('./helpers').loadFixture;
 
 describe('#extractTextBlocks', function() {
-  it('should extract the phrase', function() {
+  it('should extract the key', function() {
+    var output = subject('<Text key="foo.bar"></Text>')[0];
+    expect(output.key).toEqual('foo.bar');
+  });
+
+  it('should warn on phrase usage', function() {
+    spyOn(console, 'warn');
     var output = subject('<Text phrase="foo.bar"></Text>')[0];
-    expect(output.phrase).toEqual('foo.bar');
+    expect(output.key).toEqual('foo.bar');
+    expect(console.warn).toHaveBeenCalled();
   });
 
   it('should extract parameters', function() {
-    var output = subject('<Text phrase="bar" articleUrl="http://www.google.com"></Text>')[0];
+    var output = subject('<Text key="bar" articleUrl="http://www.google.com"></Text>')[0];
 
     expect(output.options).toEqual({
       article_url: 'http://www.google.com'
@@ -17,7 +24,7 @@ describe('#extractTextBlocks', function() {
   });
 
   it('should leave {parameters} untouched', function() {
-    var output = subject('<Text phrase="foo.bar" articleUrl={url}></Text>')[0];
+    var output = subject('<Text key="foo.bar" articleUrl={url}></Text>')[0];
 
     expect(output.options).toEqual({
       article_url: '{url}'
@@ -26,13 +33,13 @@ describe('#extractTextBlocks', function() {
 
   describe('#stringValue', function() {
     it('should produce an I18n.t() call string', function() {
-      var output = subject('<Text phrase="foo.bar" articleUrl={url}></Text>')[0];
+      var output = subject('<Text key="foo.bar" articleUrl={url}></Text>')[0];
 
       expect(output.stringValue).toEqual('I18n.t("foo.bar", "", {"article_url":url})');
     });
 
     it('should include de-interpolated strings', function() {
-      var output = subject('<Text phrase="foo.bar" articleUrl={url}>Click <a href="%{article_url}">here</a>.</Text>')[0];
+      var output = subject('<Text key="foo.bar" articleUrl={url}>Click <a href="%{article_url}">here</a>.</Text>')[0];
 
       expect(output.stringValue).toEqual('I18n.t("foo.bar", "Click <a href=\\\"%{article_url}\\\">here</a>.", {"article_url":url})');
     });
@@ -43,8 +50,8 @@ describe('#extractTextBlocks', function() {
       'render: function() {',
         'return (',
           '<div>',
-            '<Text phrase="foo.x">X goes here.</Text>',
-            '<Text phrase="foo.y">Y goes there.</Text>',
+            '<Text key="foo.x">X goes here.</Text>',
+            '<Text key="foo.y">Y goes there.</Text>',
           '</div>',
         ');',
       '}'
@@ -52,20 +59,20 @@ describe('#extractTextBlocks', function() {
 
     expect(output.length).toBe(2);
 
-    expect(output[0].phrase).toBe('foo.x');
+    expect(output[0].key).toBe('foo.x');
     expect(output[0].defaultValue).toBe('X goes here.');
-    expect(output[0].offset).toEqual([ 36, 76 ]);
+    expect(output[0].offset).toEqual([ 36, 73 ]);
 
-    expect(output[1].phrase).toBe('foo.y');
+    expect(output[1].key).toBe('foo.y');
     expect(output[1].defaultValue).toBe('Y goes there.');
-    expect(output[1].offset).toEqual([ 77, 118 ]);
+    expect(output[1].offset).toEqual([ 74, 112 ]);
   });
 
   describe('#compile', function() {
     it('should return a newly-compiled I18n.t() directive', function() {
-      var output = subject('<Text phrase="foo.bar" articleUrl={url}></Text>')[0];
+      var output = subject('<Text key="foo.bar" articleUrl={url}></Text>')[0];
 
-      output.phrase = 'foo';
+      output.key = 'foo';
       output.options = { name: 'Ahmad' };
       expect(output.compile()).toEqual('I18n.t("foo", "", {"name":"Ahmad"})');
     });

--- a/test/extract_text_blocks_spec.js
+++ b/test/extract_text_blocks_spec.js
@@ -46,7 +46,19 @@ describe('#extractTextBlocks', function() {
     it('should include de-interpolated strings', function() {
       var output = subject('<Text key="foo.bar" articleUrl={url}>Click <a href="%{article_url}">here</a>.</Text>')[0];
 
-      expect(output.stringValue).toEqual('I18n.t("foo.bar", "Click <a href=\\\"%{article_url}\\\">here</a>.", {"article_url":url})');
+      expect(output.stringValue).toEqual('I18n.t("foo.bar", "Click <a href=\\"%{article_url}\\">here</a>.", {"article_url":url})');
+    });
+
+    it('should infer sensible placeholders from expressions', function() {
+      var output = subject('<Text key="foo.bar">Hello {this.props.user.name}</Text>')[0];
+
+      expect(output.stringValue).toEqual('I18n.t("foo.bar", "Hello %{user_name}", {"user_name":this.props.user.name})');
+    });
+
+    it('should infer quoted placeholders from expressions in markup attributes', function() {
+      var output = subject('<Text key="foo.bar">Click <a href={title}>here</a></Text>')[0];
+
+      expect(output.stringValue).toEqual('I18n.t("foo.bar", "Click <a href=\\"%{title}\\">here</a>", {"title":title})');
     });
   });
 

--- a/test/extract_text_blocks_spec.js
+++ b/test/extract_text_blocks_spec.js
@@ -15,6 +15,11 @@ describe('#extractTextBlocks', function() {
     expect(console.warn).toHaveBeenCalled();
   });
 
+  it('should infer a key if none is provided', function() {
+    var output = subject('<Text>Hello World</Text>')[0];
+    expect(output.key).toEqual('hello_world_e2033670');
+  });
+
   it('should extract parameters', function() {
     var output = subject('<Text key="bar" articleUrl="http://www.google.com"></Text>')[0];
 

--- a/test/fixtures/transform.in.jsx
+++ b/test/fixtures/transform.in.jsx
@@ -8,7 +8,7 @@ define(function(require) {
     render: function() {
       return(
         <Text
-          phrase="discrimination_index_help"
+          key="discrimination_index_help"
           articleUrl={K.DISCRIMINATION_INDEX_HELP_ARTICLE_URL}>
           <p>
             This metric provides a measure of how well a single question can tell the

--- a/test/fixtures/transform_multi.in.jsx
+++ b/test/fixtures/transform_multi.in.jsx
@@ -11,7 +11,7 @@ define(function(require) {
       return(
         <div>
           <Text
-            phrase="discrimination_index_help"
+            key="discrimination_index_help"
             articleUrl={K.DISCRIMINATION_INDEX_HELP_ARTICLE_URL}>
             <p>
               This metric provides a measure of how well a single question can tell the
@@ -37,9 +37,9 @@ define(function(require) {
 
           <span>Separator</span>
 
-          <Text phrase="adooken">Adooken!</Text>
-          <Text phrase="adooken_y">Adooken Y!</Text>
-          <Text phrase="foo">
+          <Text key="adooken">Adooken!</Text>
+          <Text key="adooken_y">Adooken Y!</Text>
+          <Text key="foo">
             <p>
               This metric provides a measure of how well a single question can tell the
               difference (or discriminate) between students who do well on an exam and

--- a/test/fixtures/transform_multi.in.jsx
+++ b/test/fixtures/transform_multi.in.jsx
@@ -46,6 +46,13 @@ define(function(require) {
               those who do not.
             </p>
           </Text>
+          <Text>
+            Hey {this.props.amigo}!
+            Although I am <a href="/" title={this.props.title}>linking to something</a> and have some
+            <strong>bold text</strong>, the translators will see <em>
+            absolutely no markup</em> and will only have a single
+            string to translate :o
+          </Text>
         </div>
       );
     }

--- a/test/fixtures/transform_multi.out.jsx
+++ b/test/fixtures/transform_multi.out.jsx
@@ -17,6 +17,7 @@ define(function(require) {
           <div dangerouslySetInnerHTML={{ __html: (function(){var wrapper={};return I18n.t("adooken", "Adooken!", {"wrapper":wrapper});}()) }} />
           <div dangerouslySetInnerHTML={{ __html: (function(){var wrapper={};return I18n.t("adooken_y", "Adooken Y!", {"wrapper":wrapper});}()) }} />
           <div dangerouslySetInnerHTML={{ __html: (function(){var wrapper={"*":"<p>$1</p>"};return I18n.t("foo", "* This metric provides a measure of how well a single question can tell the difference (or discriminate) between students who do well on an exam and those who do not. *", {"wrapper":wrapper});}()) }} />
+          <div dangerouslySetInnerHTML={{ __html: (function(){var wrapper={"***":"<em>$1</em>","**":"<strong>$1</strong>","*":"<a href=\"/\" title=\"%{title}\">$1</a>"};return I18n.t("hey_amigo_although_i_am_a_href_title_title_linking_273e3da5", "Hey %{amigo}! Although I am *linking to something* and have some **bold text**, the translators will see *** absolutely no markup*** and will only have a single string to translate :o", {"amigo":this.props.amigo,"title":this.props.title,"wrapper":wrapper});}()) }} />
         </div>
       );
     }


### PR DESCRIPTION
several tweaks to make it easier to use, like i18nliner-handlebars...

1. keys are optional and will be inferred if not provided
2. placeholders can be inferred; you can simply use js expressions, and don't need to explicitly set any interpolation attributes on the `<Text>` node

an example borrowed from i18nliner:

```html
<Text>
  Hey {this.props.amigo}!
  Although I am <a href="/" title={this.props.title}>linking to something</a> and have some
  <strong>bold text</strong>, the translators will see <em>
  absolutely no markup</em> and will only have a single
  string to translate :o
</Text>
```

the key is inferred according to i18nliner's rules, and the placeholders in this example will just be `amigo` and `title` 